### PR TITLE
Expose additional optional features in the config (ex: maxAlternatives)

### DIFF
--- a/speech-android-wrapper/src/main/java/com/ibm/watson/developer_cloud/android/speech_to_text/v1/audio/WebSocketUploader.java
+++ b/speech-android-wrapper/src/main/java/com/ibm/watson/developer_cloud/android/speech_to_text/v1/audio/WebSocketUploader.java
@@ -291,9 +291,17 @@ public class WebSocketUploader extends WebSocketClient implements IChunkUploader
         try {
             obj.put("action", "start");
             obj.put("content-type", this.sConfig.audioFormat);
-            obj.put("interim_results", true);
+            obj.put("interim_results", this.sConfig.returnInterimResults);
             obj.put("continuous", true);
             obj.put("inactivity_timeout", this.sConfig.inactivityTimeout);
+
+            if (this.sConfig.maxAlternatives > 1) {
+                obj.put("max_alternatives", this.sConfig.maxAlternatives);
+            }
+
+            if (!(Float.isNaN(this.sConfig.wordAlternativesThreshold))) {
+                obj.put("word_alternatives_threshold", this.sConfig.wordAlternativesThreshold);
+            }
         } catch (JSONException e) {
             e.printStackTrace();
         }

--- a/speech-android-wrapper/src/main/java/com/ibm/watson/developer_cloud/android/speech_to_text/v1/dto/SpeechConfiguration.java
+++ b/speech-android-wrapper/src/main/java/com/ibm/watson/developer_cloud/android/speech_to_text/v1/dto/SpeechConfiguration.java
@@ -42,6 +42,13 @@ public class SpeechConfiguration {
     public boolean isSSL = true;
     // Default timeout duration for a connection
     public int connectionTimeout = 30000;
+    // Interim results are intermediate hypotheses of a transcription that are likely to change before the service returns the final result. Interim results are useful for real-time transcription, for example, to obtain alternative transcriptions for a dictation application.
+    public boolean returnInterimResults = true;
+    // An integer value that tells the service to return the n-best alternative hypotheses
+    public int maxAlternatives = 1;
+    // Reports hypotheses for acoustically similar alternatives for words of the input audio
+    public float wordAlternativesThreshold = Float.NaN;
+
     /**
      * Instantiate default configuration
      */


### PR DESCRIPTION
Some of the features available in the websocket API aren't exposed for Android, so adding config variables and exposing them.  ex: https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/doc/speech-to-text/output.shtml#max_alternatives
